### PR TITLE
Lógica del buscador de Pokémones

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,2 @@
-<!-- <app-navegador></app-navegador> -->
+<app-navegador></app-navegador>
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,14 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
 import { NavegadorComponent } from './navegador/navegador.component';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NavegadorComponent],
+  imports: [NavegadorComponent, RouterOutlet],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
 export class AppComponent {
-  title = 'Fanpolis';
+  title = 'FanPolis';
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -11,7 +11,7 @@ export const routes: Routes = [
   { path: '', redirectTo: '/home', pathMatch: 'full' },
   { path: 'home', component: PaginaprinComponent },
   { path: 'features', component: ColeccionComponent },
-  { path: 'rampage', component: RmpageComponent},
+  // { path: 'rampage', component: RmpageComponent},
   { path: 'pkpage', component: PkpageComponent},
   //   { path: 'pricing', component: PricingComponent },
   { path: '**', redirectTo: '/home' },

--- a/src/app/navegador/navegador.component.css
+++ b/src/app/navegador/navegador.component.css
@@ -30,6 +30,50 @@
   transform: scale(1);
 }
 
+/* Estilos para los resultados de búsqueda */
+.search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background-color: white;
+  border-radius: 0.25rem;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 1050;
+  margin-top: 5px;
+}
+
+.search-results-list {
+  padding: 0.5rem 0;
+}
+
+.search-result-item {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.search-result-item:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.search-result-img {
+  width: 40px;
+  height: 40px;
+  margin-right: 10px;
+  object-fit: contain;
+}
+
+.search-result-name {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #333;
+}
+
 .nav-link:hover {
   background-color: rgba(255, 255, 255, 0.1);
   transform: scale(1.05);

--- a/src/app/navegador/navegador.component.html
+++ b/src/app/navegador/navegador.component.html
@@ -14,9 +14,26 @@
           <a class="nav-link" routerLink="/features" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Features</a>
         </li>
       </ul>
-      <form class="d-flex" role="search">
-        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-outline-light" type="submit">Search</button>
+      <form class="d-flex" role="search" (ngSubmit)="searchPokemon()">
+        <div class="position-relative w-100">
+          <input class="form-control me-2" type="search" placeholder="Buscar Pokémon" aria-label="Search" 
+                 [(ngModel)]="searchTerm" name="searchTerm" (focus)="onFocus()" (blur)="onBlur()">
+          <div *ngIf="showResults" class="search-results">
+            <div *ngIf="isSearching" class="p-3 text-center">
+              <span>Buscando...</span>
+            </div>
+            <div *ngIf="noResults && !isSearching" class="p-3 text-center">
+              <span>Este Pokémon no existe</span>
+            </div>
+            <div *ngIf="searchResults.length > 0 && !isSearching" class="search-results-list">
+              <div *ngFor="let pokemon of searchResults" class="search-result-item" (click)="viewPokemonDetails(pokemon.id)">
+                <img [src]="pokemon.imageUrl" alt="{{ pokemon.name }}" class="search-result-img">
+                <span class="search-result-name">{{ pokemon.name | titlecase }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <button class="btn btn-outline-light" type="submit">Buscar</button>
       </form>
     </div>
   </div>

--- a/src/app/navegador/navegador.component.ts
+++ b/src/app/navegador/navegador.component.ts
@@ -1,13 +1,121 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { DatabaseService } from '../database.service';
 
 @Component({
   selector: 'app-navegador',
   standalone: true,
-  imports: [RouterModule],
+  imports: [RouterModule, CommonModule, FormsModule],
   templateUrl: './navegador.component.html',
   styleUrl: './navegador.component.css'
 })
 export class NavegadorComponent {
+  searchTerm: string = '';
+  searchResults: any[] = [];
+  isSearching: boolean = false;
+  noResults: boolean = false;
+  showResults: boolean = false;
+  justSearched: boolean = false; // Variable para rastrear si se acaba de realizar una búsqueda mediante el botón
 
+  constructor(
+    private databaseService: DatabaseService,
+    private router: Router
+  ) {}
+
+  searchPokemon() {
+    if (!this.searchTerm.trim()) {
+      this.showResults = false;
+      return;
+    }
+
+    this.isSearching = true;
+    this.noResults = false;
+    this.showResults = true; // Aseguramos que los resultados se muestren al iniciar la búsqueda
+    this.justSearched = true; // Marcamos que se acaba de realizar una búsqueda mediante el botón
+    
+    // Primero intentamos buscar por nombre exacto
+    this.databaseService.getPokemonDetails(this.searchTerm.toLowerCase())
+      .subscribe({
+        next: (pokemon) => {
+          this.searchResults = [{
+            name: pokemon.name,
+            id: pokemon.id,
+            imageUrl: pokemon.sprites.other['official-artwork'].front_default || pokemon.sprites.front_default
+          }];
+          this.isSearching = false;
+          this.noResults = false;
+        },
+        error: () => {
+          // Si no encontramos coincidencia exacta, buscamos similitudes
+          this.findSimilarPokemons();
+        }
+      });
+  }
+
+  private findSimilarPokemons() {
+    // Obtenemos una lista más grande para buscar coincidencias parciales
+    this.databaseService.getPokemonList(100, 0)
+      .subscribe({
+        next: (response) => {
+          const searchTermLower = this.searchTerm.toLowerCase();
+          
+          // Filtramos los pokémon que contienen el término de búsqueda
+          const filteredResults = response.results
+            .filter(pokemon => pokemon.name.includes(searchTermLower))
+            .map(pokemon => {
+              const urlParts = pokemon.url.split('/');
+              const id = parseInt(urlParts[urlParts.length - 2]);
+              return {
+                name: pokemon.name,
+                id: id,
+                imageUrl: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${id}.png`
+              };
+            });
+
+          this.searchResults = filteredResults;
+          this.noResults = filteredResults.length === 0;
+          this.isSearching = false;
+        },
+        error: (err) => {
+          console.error('Error al buscar pokémon similares:', err);
+          this.searchResults = [];
+          this.noResults = true;
+          this.isSearching = false;
+        }
+      });
+  }
+
+  viewPokemonDetails(pokemonId: number) {
+    // Necesitamos encontrar una forma de pasar el ID del Pokémon seleccionado a la página de detalles
+    // Por ahora, solo navegamos a la página de Pokémon
+    this.router.navigate(['/pkpage'], { queryParams: { pokemonId: pokemonId } });
+    // Cerramos los resultados de búsqueda
+    this.showResults = false;
+    this.searchTerm = '';
+  }
+
+  onBlur() {
+    // Pequeño retraso para permitir que se procese el clic en un resultado
+    setTimeout(() => {
+      // No ocultamos los resultados si acabamos de realizar una búsqueda mediante el botón
+      if (!this.justSearched && !this.isSearching) {
+        this.showResults = false;
+      }
+      // Restablecemos la variable después de un tiempo para restaurar el comportamiento normal
+      if (this.justSearched) {
+        setTimeout(() => {
+          this.justSearched = false;
+        }, 3000); // Damos tiempo suficiente para que el usuario interactúe con los resultados
+      }
+    }, 200);
+  }
+
+  onFocus() {
+    if (this.searchTerm.trim() && this.searchResults.length > 0) {
+      this.showResults = true;
+    }
+  }
 }

--- a/src/app/paginaprin/paginaprin.component.html
+++ b/src/app/paginaprin/paginaprin.component.html
@@ -2,9 +2,8 @@
 
   <app-navegador></app-navegador>
 
-  <div class="hero-container" style="background-image: url('../../assets/imagenes/rickandmorty.jpg');">
+  <!-- <div class="hero-container" style="background-image: url('../../assets/imagenes/rickandmorty.jpg');">
     <div class="hero-title"><img src="../../assets/imagenes/rmlogo2.png" alt=""></div>
-    <!-- <button class="hero-button">Visit</button> -->
 
     <div class="centrarb">
       <button class="animated-button" routerLink="/rampage" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
@@ -25,7 +24,9 @@
     </div>
 
 
-  </div>
+  </div> -->
+
+
   <div class="hero-container" style="background-image: url('../../assets/imagenes/pokemon.jpg');">
     <div class="hero-title"><img src="../../assets/imagenes/pklogo.png" alt=""></div>
     <!-- <button class="hero-button">Visit</button> -->

--- a/src/app/pkpage/pkpage.component.ts
+++ b/src/app/pkpage/pkpage.component.ts
@@ -5,6 +5,7 @@ import { CommonModule } from '@angular/common';
 import { DatabaseService, PokemonListResponse } from '../database.service';
 import { FormsModule } from '@angular/forms';
 import { InfopokemonComponent } from '../infopokemon/infopokemon.component';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-pkpage',
@@ -33,7 +34,8 @@ export class PkpageComponent {
 
   constructor(
     private titleService: Title,
-    private databaseService: DatabaseService
+    private databaseService: DatabaseService,
+    private route: ActivatedRoute
   ) {
     this.titleService.setTitle('FanPolis | Pokémon');
     this.audio.src = '../../assets/audio/pktheme.mp3';
@@ -43,6 +45,25 @@ export class PkpageComponent {
   ngOnInit() {
     this.audio.play().catch(e => console.log('Error al reproducir audio:', e));
     this.loadPokemons();
+    
+    // Verificar si hay un ID de Pokémon en los parámetros de consulta
+    this.route.queryParams.subscribe(params => {
+      if (params['pokemonId']) {
+        const pokemonId = parseInt(params['pokemonId']);
+        if (!isNaN(pokemonId)) {
+          // Seleccionar el Pokémon automáticamente
+          this.selectPokemon(pokemonId);
+          
+          // Si el Pokémon no está en la página actual, buscar en qué página está
+          const itemsPerPage = this.itemsPerPage;
+          const pageNumber = Math.ceil(pokemonId / itemsPerPage);
+          if (pageNumber !== this.currentPage) {
+            this.currentPage = pageNumber;
+            this.loadPokemons();
+          }
+        }
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,3 +2,17 @@
 body{
     overflow-x: hidden;
 }
+
+body::-webkit-scrollbar {
+    width: 12px;               /* width of the entire scrollbar */
+  }
+  
+  body::-webkit-scrollbar-track {
+    background: white;        /* color of the tracking area */
+  }
+  
+  body::-webkit-scrollbar-thumb {
+    background-color: #facb04;    /* color of the scroll thumb */
+    border-radius: 20px;       /* roundness of the scroll thumb */
+    border: 3px solid #375ba9;  /* creates padding around scroll thumb */
+  }


### PR DESCRIPTION
Utilice el componente de infopokémon para mostrar el pokémon seleccionado desde el buscador. En la misma área de texto al enviar la consulta, en este caso al buscar por nombre del pokémon, actúa mi servicio de búsqueda en mi servicio "database", de manera que interactúa con la API y muestra una lista con los resultados. Como extra, filtre la consulta de manera que también puede mostrar búsquedas con no exactitudes del nombre completo, aunque primero busca por nombre completo. También le di un bonito estilo a la barra de scroll dentro de la hoja de estilos principal.